### PR TITLE
fix(reactrole): Bot reactions are ignored

### DIFF
--- a/reactrole/reactrole.py
+++ b/reactrole/reactrole.py
@@ -31,6 +31,10 @@ class ReactRoleCog(commands.Cog):
             # TODO Log error
             return
 
+        if payload.member.bot:
+            # Go no further if member is a bot
+            return
+
         guild = self.bot.get_guild(payload.guild_id)
         if guild is None:
             # Guild shouldn't be none
@@ -60,6 +64,10 @@ class ReactRoleCog(commands.Cog):
             return
 
         member = guild.get_member(payload.user_id)
+
+        if member.bot:
+            # Go no further if member is a bot
+            return
 
         if not await self.settings.guild(guild).enabled():
             # Go no further if disabled


### PR DESCRIPTION
# Initial Checklist
- [x] Has @tigattack and/or @kdavis been added as a reviewer?
- [x] If applicable, have the relevant milestone(s) and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot/blob/develop/README.md#cog-summaries)?

<!--
FILL OUT THE BELOW SECTIONS AS APPROPRIATE
-->

# Details
* **What issue is this related to (if applicable)?**  
Issue #34 

## Changes
### New Features
* Bot ignores reaction_add and reaction_remove events if the member in the payload is a bot

### Breaking Changes
N/A

## Additional
N/A