### PR TITLE
refactor(reactrole): Remove extra line break

### DIFF
--- a/reactrole/reactrole.py
+++ b/reactrole/reactrole.py
@@ -186,7 +186,7 @@ class ReactRoleCog(commands.Cog):
                     message = await channel.fetch_message(item["message"])
                     messages.append(
                         f'📝 {message.jump_url} '
-                        f'- {role.name} - {item["reaction"]}\n\n'
+                        f'- {role.name} - {item["reaction"]}\n'
                     )
                 except Exception as e:
                     print(e)


### PR DESCRIPTION
# Initial Checklist
- [x] Has @tigattack and/or @kdavis been added as a reviewer?
- [x] If applicable, have the relevant milestone(s) and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot/blob/develop/README.md#cog-summaries)?

<!--
FILL OUT THE BELOW SECTIONS AS APPROPRIATE
-->

# Details
* **What issue is this related to (if applicable)?**  
Issue #

## Changes
### New Features
* `[p]reactrole list` had two line breaks between each reactrole config. I've changed this to now have a single line break. since two left a lot of unnecessary space.

### Breaking Changes
None.

## Additional
None.
