### PR TITLE
fix(feed.py): Use member.display_name

### DIFF
--- a/feed/feed.py
+++ b/feed/feed.py
@@ -125,6 +125,6 @@ class FeedCog(commands.Cog):
         Example:
         - `[p]feed <member>`
         """
-        feed_text = f"Forces {random.choice(food)} down {member.nick if member.nick else member.user.name}'s throat"
+        feed_text = f"Forces {random.choice(food)} down {member.display_name}'s throat"
         embed = discord.Embed(title=feed_text, colour=ctx.guild.me.colour)
         await ctx.send(embed=embed)


### PR DESCRIPTION
# Initial Checklist
- [x] Has @tigattack and/or @kdavis been added as a reviewer?
- [ ] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/develop/README.md#cog-summaries)?

<!--
FILL OUT THE BELOW SECTIONS AS APPROPRIATE
-->

# Details
* **Does this resolve an issue?**
Stops the bot from erroring out when a member has no nickname