### PR TITLE
fix(report): add nullable message to report command

### DIFF
--- a/report/report.py
+++ b/report/report.py
@@ -44,7 +44,7 @@ class ReportCog(commands.Cog):
         self,
         ctx: commands.Context,
         *,
-        message: str
+        message: str = None
     ):
         """Sends a report to the mods for possible intervention
 
@@ -75,6 +75,7 @@ class ReportCog(commands.Cog):
         data.add_field(name="Reporter", value=author.mention)
         data.add_field(name="Channel", value=ctx.channel.mention)
         data.add_field(name="Timestamp", value=ctx.message.created_at)
-        data.add_field(name="Message", value=escape(message), inline=False)
+        data.add_field(name="Message", value=escape(
+            message or "<no message>"), inline=False)
 
         await log.send(embed=data)


### PR DESCRIPTION
# Initial Checklist
- [X] Has @tigattack and/or @kdavis been added as a reviewer?
- [X] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [X] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/develop/README.md#cog-summaries)?

<!--
FILL OUT THE BELOW SECTIONS AS APPROPRIATE
-->

# Details
* **Does this resolve an issue?**
Resolves #55

## Changes
### New Features
* Allows message to be null so `[p]report` will not give command instructions in the case of no message provided

### Breaking Changes
* N/A

## Additional
N/A
