### PR TITLE
fix(quotes.py): Added error checking for quote command

### DIFF
--- a/quotes/quotes.py
+++ b/quotes/quotes.py
@@ -38,7 +38,7 @@ class QuotesCog(commands.Cog):
 
     @commands.guild_only()
     @_quotes.command(name='add')
-    async def add_quote(self, ctx, *message_ids: tuple = ()):
+    async def add_quote(self, ctx, *message_ids):
         """Add a message or set of messages to the quotes channel
 
         Usage:

--- a/quotes/quotes.py
+++ b/quotes/quotes.py
@@ -2,6 +2,7 @@
 import discord
 from redbot.core import checks, commands, Config
 import asyncio
+from typing import List
 
 
 class QuotesCog(commands.Cog):
@@ -37,7 +38,7 @@ class QuotesCog(commands.Cog):
 
     @commands.guild_only()
     @_quotes.command(name='add')
-    async def add_quote(self, ctx, *message_ids):
+    async def add_quote(self, ctx, *message_ids: tuple = ()):
         """Add a message or set of messages to the quotes channel
 
         Usage:
@@ -46,12 +47,17 @@ class QuotesCog(commands.Cog):
         For multiple messages in a single quote:
         - `[p]quote add <message_id1> <message_id2> <message_id3>`
         """
+        if not message_ids:
+            error_embed = self.make_error_embed(ctx, error_type='NoArgs')
+            await ctx.send(embed=error_embed)
+            return
+
         messages = []
         # Collect the messages
         async with ctx.channel.typing():
             for i in range(len(message_ids)):
                 if len(messages) != i:
-                    error_embed = await self.make_error_embed(ctx, custom_msg=f'Could not find message with ID `{message_ids[i-1]}`')
+                    error_embed = self.make_error_embed(ctx, custom_msg=f'Could not find message with ID `{message_ids[i-1]}`')
                     await ctx.send(embed=error_embed)
                     return
                 for channel in ctx.guild.channels:
@@ -63,7 +69,7 @@ class QuotesCog(commands.Cog):
                         continue
 
             if len(messages) < len(message_ids):
-                error_embed = await self.make_error_embed(ctx, custom_msg=f'Could not find message with ID `{message_ids[-1]}`')
+                error_embed = self.make_error_embed(ctx, custom_msg=f'Could not find message with ID `{message_ids[-1]}`')
                 await ctx.send(embed=error_embed)
                 return
 
@@ -78,46 +84,46 @@ class QuotesCog(commands.Cog):
             else:
                 formatted_quote = '\n'.join([i.content for i in messages])
 
-            quote_embed = await self.make_quote_embed(ctx, formatted_quote, messages, authors)
+            quote_embed = self.make_quote_embed(ctx, formatted_quote, messages, authors)
             quote_channel = await self.config.guild(ctx.guild).quote_channel()
 
             if not quote_channel:
-                error_embed = await self.make_error_embed(ctx, error_type='NoChannelSet')
+                error_embed = self.make_error_embed(ctx, error_type='NoChannelSet')
                 await ctx.send(embed=error_embed)
                 return
 
             try:
                 quote_channel = await self.bot.fetch_channel(quote_channel)
             except Exception:
-                error_embed = await self.make_error_embed(ctx, error_type='ChannelNotFound')
+                error_embed = self.make_error_embed(ctx, error_type='ChannelNotFound')
                 await ctx.send(embed=error_embed)
                 return
 
         try:
-            messageObject = await ctx.send(embed=quote_embed, content='Are you sure you want to send this quote?')
+            message_object = await ctx.send(embed=quote_embed, content='Are you sure you want to send this quote?')
         # If sending the quote failed for any reason. For example, quote exceeded the character limit
         except Exception as err:
-            error_embed = await self.make_error_embed(ctx, custom_msg=err)
+            error_embed = self.make_error_embed(ctx, custom_msg=err)
             await ctx.send(embed=error_embed)
 
         emojis = ['✅', '❌']
         for emoji in emojis:
-            await messageObject.add_reaction(emoji)
+            await message_object.add_reaction(emoji)
 
         def reaction_check(reaction, user):
-            return (user == ctx.author) and (reaction.message.id == messageObject.id) and (reaction.emoji in emojis)
+            return (user == ctx.author) and (reaction.message.id == message_object.id) and (reaction.emoji in emojis)
 
         try:
             reaction, user = await self.bot.wait_for('reaction_add', timeout=180.0, check=reaction_check)
         except asyncio.TimeoutError:
             try:
-                await messageObject.clear_reactions()
+                await message_object.clear_reactions()
             except Exception:
                 pass
             return
         else:
             if reaction.emoji == '❌':
-                await messageObject.clear_reactions()
+                await message_object.clear_reactions()
                 return
             await quote_channel.send(embed=quote_embed)
             success_embed = discord.Embed(description='Your quote has been sent', colour=ctx.guild.me.colour)
@@ -125,7 +131,7 @@ class QuotesCog(commands.Cog):
 
 # Helper functions
 
-    async def make_quote_embed(self, ctx, formatted_quote, messages, authors):
+    def make_quote_embed(self, ctx, formatted_quote: str, messages: List[discord.Message], authors: List[discord.Member]) -> discord.Embed:
         """Generate the quote embed to be sent"""
         author_list = ' '.join([i.mention for i in authors])
         channels = []
@@ -144,14 +150,15 @@ class QuotesCog(commands.Cog):
         quote_embed.add_field(name='Link', value=f'[Jump to quote]({messages[0].jump_url})', inline=True)
         return quote_embed
 
-    async def make_error_embed(self, ctx, error_type: str = '', custom_msg: str = None):
+    def make_error_embed(self, ctx, error_type: str = '', custom_msg: str = None) -> discord.Embed:
         """Generate error message embeds"""
         error_msgs = {
             'NoChannelSet': f"""There is no quotes channel configured for this server.
         A moderator must set a quotes channel for this server using the command `{ctx.prefix}quote set_quotes_channel <channel>`""",
             'ChannelNotFound': f"""Unable to find the quotes channel for this server. This could be due to a permissions issue or because the channel no longer exists.
 
-        A moderator must set a valid quotes channel for this server using the command `{ctx.prefix}quote set_quotes_channel <channel>`"""
+        A moderator must set a valid quotes channel for this server using the command `{ctx.prefix}quote set_quotes_channel <channel>`""",
+            'NoArgs': 'You must provide 1 or more message IDs for this command!'
         }
 
         if error_type:


### PR DESCRIPTION
# Initial Checklist
- [x] Has @tigattack and/or @kdavis been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/develop/README.md#cog-summaries)?

<!--
FILL OUT THE BELOW SECTIONS AS APPROPRIATE
-->

# Details
* **Does this resolve an issue?**
N/A

## Changes
### New Features
* If someone doesn't provide any message IDs in the quote command, the bot will let them know instead of failing silently

### Breaking Changes
N/A

## Additional
N/A