### PR TITLE
Add VSCode tasks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 127
+extend-ignore = E203, W503
+max-complexity = 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
         run: |
           # stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --format="::warning file=%(path)s,line=%(row)d,col=%(col)d::%(text)s" --exit-zero --max-complexity=10 --max-line-length=127
+          # exit-zero treats all errors as warnings
+          flake8 . --format="::warning file=%(path)s,line=%(row)d,col=%(col)d::%(text)s" --exit-zero --max-complexity=10
 
   lint-black:
     runs-on: ubuntu-latest

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,109 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "Install task requirements",
+			"type": "process",
+			"command": "python3",
+			"args": [
+				"-m",
+				"pip",
+				"install",
+				"--requirement",
+				"requirements-ci.txt",
+				"--quiet"
+			]
+		},
+		{
+			"label": "Flake8",
+			"type": "shell",
+			"dependsOn": "Install task requirements",
+			"command": "flake8",
+			"args": [
+				".",
+				"--format=\"%(path)s:%(row)d:%(col)d %(text)s\"",
+				"--exit-zero",
+				"--max-complexity=10",
+				"--max-line-length=127"
+			],
+			"problemMatcher": {
+				"fileLocation": [
+					"relative",
+					"${workspaceFolder}"
+				],
+				"pattern": {
+					"regexp": "^(.*):(\\d+):(\\d+) (.*)$",
+					"file": 1,
+					"line": 2,
+					"column": 3,
+					"message": 4
+				}
+			}
+		},
+		{
+			"label": "Lint with Pylint",
+			"type": "shell",
+			"dependsOn": "Install task requirements",
+			"command": "pylint",
+			"args": [
+				"--msg-template='error {path}:{line}:{column} {msg}'",
+				"*/"
+			],
+			"problemMatcher": {
+				"fileLocation": [
+					"relative",
+					"${workspaceFolder}"
+				],
+				"pattern": {
+					"regexp": "^(error|warning) (.*):(\\d+):(\\d+) (.*)$",
+					"severity": 1,
+					"file": 2,
+					"line": 3,
+					"column": 4,
+					"message": 5
+				}
+			}
+		},
+		{
+			"label": "Format with Black",
+			"type": "shell",
+			"dependsOn": "Install task requirements",
+			"command": "black",
+			"args": [
+				"."
+			],
+			"problemMatcher": []
+		},
+		{
+			"label": "Sort imports with isort",
+			"type": "process",
+			"dependsOn": "Install task requirements",
+			"command": "isort",
+			"args": [
+				"."
+			]
+		},
+		{
+			"label": "Check info.json files",
+			"type": "shell",
+			"dependsOn": "Install task requirements",
+			"command": "python3",
+			"args": [
+				".github/scripts/json_checker.py"
+			],
+			"problemMatcher": {
+				"fileLocation": [
+					"relative",
+					"${workspaceFolder}"
+				],
+				"pattern": {
+					"regexp": "^(.*):(\\d+):(\\d+) (.*)$",
+					"file": 1,
+					"line": 2,
+					"column": 3,
+					"message": 4
+				}
+			}
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ black . # This will auto-format and fix a lot of common mistakes
 pylint * # This will show general pep8-violations
 ```
 
+If you use [VSCode](https://code.visualstudio.com/) you can use the tasks integrated into the repo to locally run the same tasks as our CI
+
 ### Making changes
 
 When suggesting changes, please [open an issue](https://github.com/rHomelab/LabBot-Cogs/issues/new/choose) so it can be reviewed by the team who can then suggest how and if the idea is to be implemented.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,6 @@
 	ignore-docstrings = "yes"
 	# Ignore imports when computing similarities.
 	ignore-imports = "yes"
+
+[tool.pylint.messages_control]
+	disable = "C0330, C0326"


### PR DESCRIPTION
# Initial Checklist
- [x] Has @tigattack / @kdavis / @issy been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [x] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/develop/README.md#cog-summaries)?

<!--
FILL OUT THE BELOW SECTIONS AS APPROPRIATE
-->

# Details
* **Does this resolve an issue?**
Completes part of #144 

## Changes
### New Features
* Adds VSCode tasks which mimic the CI workflows
* Adds Flake8 config so it doesn't clash with Black on certain things

## Additional
To run the tasks locally just open the repo in VSCode, open the command palette and type in `run task`. This will give you a list of the available tasks you can run. Most of these tasks also have problem matchers, so if it detects issues with the code it will flag the exact line and column in the `problems` tab of VSCode