### PR TITLE
[FIX] Punctuation spacing/substitution in letters command

### DIFF
--- a/letters/info.json
+++ b/letters/info.json
@@ -1,6 +1,7 @@
 {
     "author": [
-        "tigattack"
+        "tigattack",
+        "Issy"
     ],
     "short": "Outputs large emote letters from input text.",
     "description": "Convert a string of letters/numbers into large emote letters (\"regional indicators\")",

--- a/letters/letters.py
+++ b/letters/letters.py
@@ -31,23 +31,24 @@ def convert_char(char: str) -> str:
         return f"{specials[char]} "
 
 
-async def convert_string(ctx: commands.Context, input_str: str) -> str:
-    """Convert a string to discord emojis"""
-    input_str = (await commands.clean_content(fix_channel_mentions=True).convert(ctx, input_str)).lower()
-    # Strip unsupported characters
-    if allowed_chars.search(input_str):
-        input_str = allowed_chars.sub("", input_str)
+class StringConverter(commands.Converter):
+    async def convert(self, ctx: commands.Context, input_str: str) -> str:
+        """Convert a string to discord emojis"""
+        input_str = (await commands.clean_content(fix_channel_mentions=True).convert(ctx, input_str)).lower()
+        # Strip unsupported characters
+        if allowed_chars.search(input_str):
+            input_str = allowed_chars.sub("", input_str)
 
-    # Convert characters to Discord emojis
-    letters = "".join(map(convert_char, input_str))
-    # Replace >= 3 spaces with two
-    letters = re.sub(" {3,}", "  ", letters)
-    # Correct punctuation spacing
-    letters = re.sub(r"([!?\'.#,:]) ([!?\'.#,])", r"\1\2", letters)
-    # Necessary for edge cases
-    letters = re.sub(r"([!?\'.#,:]) ([!?\'.#,])", r"\1\2", letters)
+        # Convert characters to Discord emojis
+        letters = "".join(map(convert_char, input_str))
+        # Replace >= 3 spaces with two
+        letters = re.sub(" {3,}", "  ", letters)
+        # Correct punctuation spacing
+        letters = re.sub(r"([!?\'.#,:]) ([!?\'.#,])", r"\1\2", letters)
+        # Necessary for edge cases
+        letters = re.sub(r"([!?\'.#,:]) ([!?\'.#,])", r"\1\2", letters)
 
-    return letters
+        return letters
 
 
 def raw_flag(argument: str) -> bool:

--- a/letters/letters.py
+++ b/letters/letters.py
@@ -1,4 +1,5 @@
 import re
+import discord
 from typing import Optional
 from redbot.core import commands
 
@@ -30,9 +31,9 @@ def convert_char(char: str) -> str:
         return f"{specials[char]} "
 
 
-def convert_string(input_str: str) -> str:
+async def convert_string(ctx: commands.Context, input_str: str) -> str:
     """Convert a string to discord emojis"""
-    input_str = input_str.lower()
+    input_str = (await commands.clean_content(fix_channel_mentions=True).convert(ctx, input_str)).lower()
     # Strip unsupported characters
     if allowed_chars.search(input_str):
         input_str = allowed_chars.sub("", input_str)

--- a/letters/letters.py
+++ b/letters/letters.py
@@ -1,5 +1,5 @@
 import re
-
+from typing import Optional
 from redbot.core import commands
 
 # Define numbers -> emotes tuple
@@ -32,6 +32,7 @@ def convert_char(char: str) -> str:
 
 def convert_string(input_str: str) -> str:
     """Convert a string to discord emojis"""
+    input_str = input_str.lower()
     # Strip unsupported characters
     if allowed_chars.search(input_str):
         input_str = allowed_chars.sub("", input_str)
@@ -41,16 +42,24 @@ def convert_string(input_str: str) -> str:
     # Replace >= 3 spaces with two
     letters = re.sub(" {3,}", "  ", letters)
     # Correct punctuation spacing
-    letters = re.sub(r"[!?\'.#,:] ([!?\'.#,])", r":\1", letters)
+    letters = re.sub(r"([!?\'.#,:]) ([!?\'.#,])", r"\1\2", letters)
 
     return letters
+
+
+def raw_flag(argument: str) -> bool:
+    """Raw flag converter"""
+    if argument.lower() == "-raw":
+        return True
+    else:
+        raise commands.BadArgument
 
 
 class Letters(commands.Cog):
     """Letters cog"""
 
     @commands.command()
-    async def letters(self, ctx, *, msg):
+    async def letters(self, ctx: commands.Context, raw: Optional[raw_flag] = False, *, msg: convert_string):
         """Outputs large emote letters (\"regional indicators\") from input text.
 
         The result can be outputted as raw emote code using `-raw` flag.
@@ -59,19 +68,7 @@ class Letters(commands.Cog):
         - `[p]letters I would like this text as emotes 123`
         - `[p]letters -raw I would like this text as raw emote code 123`
         """
-
-        # Grab message content
-        input = msg.lower()
-
-        # Check for raw flag
-        raw = False
-        if input.startswith("-raw"):
-            raw = True
-            input = input.lstrip("-raw").lstrip()
-
-        # Define output
-        letters = convert_string(input)
-        output = f"```{letters}```" if raw else letters
+        output = f"```{msg}```" if raw else msg
 
         # Ensure output isn't too long
         if len(output) > 2000:

--- a/letters/letters.py
+++ b/letters/letters.py
@@ -36,7 +36,7 @@ def correct_punctuation_spacing(input_str: str) -> str:
     return re.sub(r"([!?'.#,:]) ([!?'.#,])", r"\1\2", input_str)
 
 
-def string_converter(self, ctx: commands.Context, input_str: str) -> str:
+def string_converter(input_str: str) -> str:
     """Convert a string to discord emojis"""
     # Make the whole string lowercase
     input_str = input_str.lower()

--- a/letters/letters.py
+++ b/letters/letters.py
@@ -43,6 +43,8 @@ def convert_string(input_str: str) -> str:
     letters = re.sub(" {3,}", "  ", letters)
     # Correct punctuation spacing
     letters = re.sub(r"([!?\'.#,:]) ([!?\'.#,])", r"\1\2", letters)
+    # Necessary for edge cases
+    letters = re.sub(r"([!?\'.#,:]) ([!?\'.#,])", r"\1\2", letters)
 
     return letters
 

--- a/letters/letters.py
+++ b/letters/letters.py
@@ -38,6 +38,11 @@ def correct_punctuation_spacing(input_str: str) -> str:
 
 def string_converter(input_str: str) -> str:
     """Convert a string to discord emojis"""
+    # NOTE In future it would be ideal to convert this function to an advanced converter (https://discordpy.readthedocs.io/en/latest/ext/commands/commands.html#advanced-converters)
+    # So we can bootstrap the commands.clean_content converter and escape channel/user/role mentions (currently there is no ping exploit; it just looks odd when converted)
+    # However, the current version of the commands.clean_content converter doesn't actually work on an argument; it scans the whole message content.
+    # This has been fixed in discord.py 2.0
+
     # Make the whole string lowercase
     input_str = input_str.lower()
     # Strip unsupported characters

--- a/letters/letters.py
+++ b/letters/letters.py
@@ -63,7 +63,7 @@ class Letters(commands.Cog):
     """Letters cog"""
 
     @commands.command()
-    async def letters(self, ctx: commands.Context, raw: Optional[raw_flag] = False, *, msg: convert_string):
+    async def letters(self, ctx: commands.Context, raw: Optional[raw_flag] = False, *, msg: StringConverter):
         """Outputs large emote letters (\"regional indicators\") from input text.
 
         The result can be outputted as raw emote code using `-raw` flag.


### PR DESCRIPTION
# Initial Checklist
- [x] Has @tigattack / @issy been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/develop/README.md#cog-summaries)?

<!--
FILL OUT THE BELOW SECTIONS AS APPROPRIATE
-->

# Details
* **Does this resolve an issue?**
Fixes some buggy behaviour in the letters command regarding punctuation.
**Before** `....` => `:. :.`
**Now** `....` => `....`

## Changes
### Features / Fixes
* Fixes the punctuation spacing/substitution in the letters command
* Moved the bulk of the letters functionality to command arg converters

### Breaking Changes
* N/A

## Additional
I wanted to utilise the `commands.clean_content` converter to aid with cleaning up user/role/channel mentions, but the current version of the provided converter does not implement the expected functionality properly. In discord.py 2.0 it is fixed, so when that's released we can resolve that.