### PR TITLE
Fix `[p]notes list` command

### DIFF
--- a/notes/utils.py
+++ b/notes/utils.py
@@ -32,7 +32,7 @@ class Note(NoteABC):
     def from_storage(cls, ctx: commands.Context, data: dict, *, is_warning: bool = False):
         return cls(
             note_id=data["id"],
-            member_id=data["member"],
+            member_id=int(data["member"]),
             message=data["message"],
             reporter_id=data["reporter"],
             reporter_name=data["reporterstr"],

--- a/notes/utils.py
+++ b/notes/utils.py
@@ -32,7 +32,7 @@ class Note(NoteABC):
     def from_storage(cls, ctx: commands.Context, data: dict, *, is_warning: bool = False):
         return cls(
             note_id=data["id"],
-            member_id=int(data["member"]),
+            member_id=int(data["member"]),  # FIXME: Migrate all stored values to int
             message=data["message"],
             reporter_id=data["reporter"],
             reporter_name=data["reporterstr"],


### PR DESCRIPTION
# Initial Checklist
- [x] Has @tigattack / @issy been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/develop/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**
Resolves an issue with the `[p]notes list` command where it would crash if there were stored notes that had been added while the note target user was not in the guild.
This stems from an issue in the [original notes cog](https://github.com/rHomelab/LabBot-Cogs/commit/520400695ccd7a91b7cdd828cb32edd5e5025417#diff-8268e6909724c46561b0b0417d6f74552c4045377e4578746f023793ac5d7bd5R53) (pre refactor) where if a note was added by user ID for a user not in the guild, the `member_id` field would be stored as a string instead of an integer. In the refactor, note data is typechecked, so this failed the typechecking every time notes were retrieved from config.

## Changes
### Features / Fixes
* Fixes `[p]notes list` command

### Breaking Changes
* N/A

## Additional
In the future I will implement a data migration task to change all stored notes so that they have the correct type in the `member_id` field. 