### PR TITLE
fix(notes): Cast created_at to int (#196)

### DIFF
--- a/notes/abstracts.py
+++ b/notes/abstracts.py
@@ -15,7 +15,7 @@ class NoteABC(ABC):
     message: str
     reporter_id: int
     reporter_name: str
-    created_at: float
+    created_at: int
     deleted: bool
     is_warning: bool
     _guild: discord.Guild

--- a/notes/utils.py
+++ b/notes/utils.py
@@ -22,7 +22,7 @@ class Note(NoteABC):
             message=message,
             reporter_id=ctx.author.id,
             reporter_name=ctx.author.name,
-            created_at=datetime.utcnow().timestamp(),
+            created_at=int(datetime.utcnow().timestamp()),
             deleted=False,
             is_warning=is_warning,
             _guild=ctx.guild,
@@ -36,7 +36,7 @@ class Note(NoteABC):
             message=data["message"],
             reporter_id=data["reporter"],
             reporter_name=data["reporterstr"],
-            created_at=data["date"],
+            created_at=int(data["date"]),  # FIXME: Migrate all stored values to int
             deleted=data["deleted"],
             is_warning=is_warning,
             _guild=ctx.guild,


### PR DESCRIPTION
# Initial Checklist
- [x] Has @tigattack / @issy been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/develop/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**
Resolves an issue with the `[p]notes list` command

## Changes
### Features / Fixes
- Sets the correct field type when retrieving and creating notes
