### PR TITLE
Fortify URL matching in phishing detection cog

### DIFF
--- a/phishingdetection/phishingdetection.py
+++ b/phishingdetection/phishingdetection.py
@@ -90,7 +90,8 @@ class PhishingDetectionCog(commands.Cog):
         # TODO: Maybe log this somewhere?
 
     def update_predicate(self):
-        pattern = re.compile("|".join(escape_url(url) for url in self.urls))
+        urls_section = "|".join(escape_url(url) for url in self.urls)
+        pattern = re.compile(f"(http[s]?://| |^)(www\\.)?({urls_section})")
 
         def predicate(content: str) -> bool:
             return bool(pattern.search(content))


### PR DESCRIPTION
# Initial Checklist
- [x] Has @tigattack / @issy been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/develop/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**
Matches URLs properly, instead of allowing for overmatching (twitch.tv was matching because of a URL called witch.tv in the banlist)

Here is an example of the new pattern in action 
![image](https://user-images.githubusercontent.com/48881813/158915295-302e1f8e-568d-4471-bd70-c7137e87c321.png)
