### PR TITLE
chore(pylint): remove useless option values

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,6 @@
 [tool.pylint.MASTER]
 	disable = [
 		"C0114", # Missing module docstring
-		"R0201", # No self use
-		"C0330" # Hanging indentation
 	]
 	max-attributes = 12
 	max-branches = 20
@@ -34,9 +32,6 @@
 	ignore-docstrings = "yes"
 	# Ignore imports when computing similarities.
 	ignore-imports = "yes"
-
-[tool.pylint.messages_control]
-	disable = "C0330, C0326"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
# Initial Checklist
- [x] Has @tigattack / @issy been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/develop/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details

Removes useless PyLint options:

* R0201 (`no-self-use`) was removed in PyCQA/pylint/pull/6448
* C0330 (`bad-continuation`) was removed in PyCQA/pylint/pull/3571
* C0326 (`bad-whitespace`) was removed in PyCQA/pylint/pull/3577
