### PR TITLE
Fix badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src=LabBot.png width="256" height="256">
 </p>
 <p align="center">
-  <img src="https://img.shields.io/github/workflow/status/rhomelab/labbot-cogs/CI?style=for-the-badge">
+  <img src="https://img.shields.io/github/actions/workflow/status/rhomelab/labbot-cogs/ci.yml?style=for-the-badge">
 <p>
 
 Cogs for the [RED](https://github.com/Cog-Creators/Red-DiscordBot/)-based [Homelab](https://reddit.com/r/Homelab) Discord server bot.


### PR DESCRIPTION
# Initial Checklist
- [x] Has @tigattack / @issy been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/master/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
Fixes the 'build' badge in the readme, which was broken due to badges/shields#8671

## Changes
### Features / Fixes
* Readme badge for build status

### Breaking Changes
N/A

## Additional
N/A
