### PR TITLE
Complete Red 3.5.1 Migration

### DIFF
--- a/autoreact/__init__.py
+++ b/autoreact/__init__.py
@@ -1,5 +1,7 @@
+from redbot.core.bot import Red
+
 from .autoreact import AutoReactCog
 
 
-def setup(bot):
-    bot.add_cog(AutoReactCog(bot))
+async def setup(bot: Red):
+    await bot.add_cog(AutoReactCog(bot))

--- a/autoreply/__init__.py
+++ b/autoreply/__init__.py
@@ -1,5 +1,7 @@
+from redbot.core.bot import Red
+
 from .autoreply import AutoReplyCog
 
 
-def setup(bot):
-    bot.add_cog(AutoReplyCog(bot))
+async def setup(bot: Red):
+    await bot.add_cog(AutoReplyCog(bot))

--- a/convert/__init__.py
+++ b/convert/__init__.py
@@ -1,5 +1,7 @@
+from redbot.core.bot import Red
+
 from .convert import Convert
 
 
-def setup(bot):
-    bot.add_cog(Convert())
+async def setup(bot: Red):
+    await bot.add_cog(Convert())

--- a/custom_msg/__init__.py
+++ b/custom_msg/__init__.py
@@ -3,5 +3,5 @@ from redbot.core.bot import Red
 from .custom_msg import CustomMsgCog
 
 
-def setup(bot: Red):
-    bot.add_cog(CustomMsgCog())
+async def setup(bot: Red):
+    await bot.add_cog(CustomMsgCog())

--- a/enforcer/__init__.py
+++ b/enforcer/__init__.py
@@ -1,5 +1,7 @@
+from redbot.core.bot import Red
+
 from .enforcer import EnforcerCog
 
 
-def setup(bot):
-    bot.add_cog(EnforcerCog(bot))
+async def setup(bot: Red):
+    await bot.add_cog(EnforcerCog(bot))

--- a/feed/__init__.py
+++ b/feed/__init__.py
@@ -1,5 +1,7 @@
+from redbot.core.bot import Red
+
 from .feed import FeedCog
 
 
-def setup(bot):
-    bot.add_cog(FeedCog())
+async def setup(bot: Red):
+    await bot.add_cog(FeedCog())

--- a/google/__init__.py
+++ b/google/__init__.py
@@ -1,5 +1,7 @@
+from redbot.core.bot import Red
+
 from .google import Google
 
 
-def setup(bot):
-    bot.add_cog(Google())
+async def setup(bot: Red):
+    await bot.add_cog(Google())

--- a/latex/__init__.py
+++ b/latex/__init__.py
@@ -1,5 +1,7 @@
+from redbot.core.bot import Red
+
 from .latex import LatexCog
 
 
-def setup(bot):
-    bot.add_cog(LatexCog())
+async def setup(bot: Red):
+    await bot.add_cog(LatexCog())

--- a/letters/__init__.py
+++ b/letters/__init__.py
@@ -1,5 +1,7 @@
+from redbot.core.bot import Red
+
 from .letters import Letters
 
 
-def setup(bot):
-    bot.add_cog(Letters())
+async def setup(bot: Red):
+    await bot.add_cog(Letters())

--- a/notes/__init__.py
+++ b/notes/__init__.py
@@ -3,5 +3,5 @@ from redbot.core.bot import Red
 from .notes import NotesCog
 
 
-def setup(bot: Red):
-    bot.add_cog(NotesCog())
+async def setup(bot: Red):
+    await bot.add_cog(NotesCog())

--- a/penis/__init__.py
+++ b/penis/__init__.py
@@ -1,5 +1,7 @@
+from redbot.core.bot import Red
+
 from .penis import Penis
 
 
-def setup(bot):
-    bot.add_cog(Penis())
+async def setup(bot: Red):
+    await bot.add_cog(Penis())

--- a/phishingdetection/__init__.py
+++ b/phishingdetection/__init__.py
@@ -3,5 +3,5 @@ from redbot.core.bot import Red
 from .phishingdetection import PhishingDetectionCog
 
 
-def setup(bot: Red):
-    bot.add_cog(PhishingDetectionCog(bot))
+async def setup(bot: Red):
+    await bot.add_cog(PhishingDetectionCog(bot))

--- a/purge/__init__.py
+++ b/purge/__init__.py
@@ -1,5 +1,7 @@
+from redbot.core.bot import Red
+
 from .purge import PurgeCog
 
 
-def setup(bot):
-    bot.add_cog(PurgeCog(bot))
+async def setup(bot: Red):
+    await bot.add_cog(PurgeCog(bot))

--- a/quotes/__init__.py
+++ b/quotes/__init__.py
@@ -1,5 +1,7 @@
+from redbot.core.bot import Red
+
 from .quotes import QuotesCog
 
 
-def setup(bot):
-    bot.add_cog(QuotesCog(bot))
+async def setup(bot: Red):
+    await bot.add_cog(QuotesCog(bot))

--- a/reactrole/__init__.py
+++ b/reactrole/__init__.py
@@ -1,5 +1,7 @@
+from redbot.core.bot import Red
+
 from .reactrole import ReactRoleCog
 
 
-def setup(bot):
-    bot.add_cog(ReactRoleCog(bot))
+async def setup(bot: Red):
+    await bot.add_cog(ReactRoleCog(bot))

--- a/report/__init__.py
+++ b/report/__init__.py
@@ -3,5 +3,5 @@ from redbot.core.bot import Red
 from .report import ReportCog
 
 
-def setup(bot: Red):
-    bot.add_cog(ReportCog(bot))
+async def setup(bot: Red):
+    await bot.add_cog(ReportCog(bot))

--- a/roleinfo/__init__.py
+++ b/roleinfo/__init__.py
@@ -3,5 +3,5 @@ from redbot.core.bot import Red
 from .roleinfo import RoleInfoCog
 
 
-def setup(bot: Red):
-    bot.add_cog(RoleInfoCog(bot))
+async def setup(bot: Red):
+    await bot.add_cog(RoleInfoCog(bot))

--- a/sentry/__init__.py
+++ b/sentry/__init__.py
@@ -1,5 +1,7 @@
+from redbot.core.bot import Red
+
 from .sentry import SentryCog
 
 
-def setup(bot):
-    bot.add_cog(SentryCog(bot))
+async def setup(bot: Red):
+    await bot.add_cog(SentryCog(bot))

--- a/timeout/__init__.py
+++ b/timeout/__init__.py
@@ -1,3 +1,4 @@
+from redbot.core.bot import Red
 from redbot.core.utils import get_end_user_data_statement
 
 from .timeout import Timeout
@@ -5,5 +6,5 @@ from .timeout import Timeout
 __red_end_user_data_statement__ = get_end_user_data_statement(__file__)
 
 
-def setup(bot):
-    bot.add_cog(Timeout())
+async def setup(bot: Red):
+    await bot.add_cog(Timeout())

--- a/verify/__init__.py
+++ b/verify/__init__.py
@@ -1,5 +1,7 @@
+from redbot.core.bot import Red
+
 from .verify import VerifyCog
 
 
-def setup(bot):
-    bot.add_cog(VerifyCog(bot))
+async def setup(bot: Red):
+    await bot.add_cog(VerifyCog(bot))

--- a/xkcd/__init__.py
+++ b/xkcd/__init__.py
@@ -1,5 +1,7 @@
+from redbot.core.bot import Red
+
 from .xkcd import Xkcd
 
 
-def setup(bot):
-    bot.add_cog(Xkcd())
+async def setup(bot: Red):
+    await bot.add_cog(Xkcd())


### PR DESCRIPTION
# Initial Checklist
- [x] Has @tigattack / @issy been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [x] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**
Resolves #221 

## Changes
### Features / Fixes
* Made cog functions async and awaits `add_cog`
* Switched to typed bot parameter for `setup(redbot.core.bot.Red)`

### Breaking Changes
* Shouldn't be any.

## Additional
I created a test instance and loaded a few cogs including 'roleinfo' since it relied on `is_mod_or_superior` which was noted as a breaking change in the 3.5.1 release notes (though, different package so this shouldn't break anyway). I also loaded 'notes' specifically due to its criticality and had no issues doing basic interactions with the cog. I'm not aware of any other breaking changes from Red 3.5.1 that should be tested.
