### PR TITLE
Fix: use Member.display_avatar.url instead of Member.avatar_url

### DIFF
--- a/enforcer/enforcer.py
+++ b/enforcer/enforcer.py
@@ -70,7 +70,7 @@ class EnforcerCog(commands.Cog):
         author = message.author
 
         data = discord.Embed(color=discord.Color.orange(), description=message.content)
-        data.set_author(name=f"Message Enforced - {author}", icon_url=author.avatar_url)
+        data.set_author(name=f"Message Enforced - {author}", icon_url=author.display_avatar.url)
         data.add_field(name="Enforced Reason", value=reason, inline=True)
         data.add_field(name="Channel", value=message.channel.mention, inline=True)
 

--- a/report/report.py
+++ b/report/report.py
@@ -177,7 +177,7 @@ class ReportCog(commands.Cog):
                 colour=discord.Colour.red() if emergency else discord.Colour.orange(),
                 description=escape(message or "<no message>"),
             )
-            .set_author(name="Report", icon_url=ctx.author.avatar_url)
+            .set_author(name="Report", icon_url=ctx.author.display_avatar.url)
             .add_field(name="Reporter", value=ctx.author.mention)
             .add_field(name="Channel", value=ctx.channel.mention)
             .add_field(name="Timestamp", value=f"<t:{int(ctx.message.created_at.timestamp())}:F>")

--- a/report/report.py
+++ b/report/report.py
@@ -190,7 +190,7 @@ class ReportCog(commands.Cog):
                 colour=discord.Colour.red() if emergency else discord.Colour.orange(),
                 description=escape(message or "<no message>"),
             )
-            .set_author(name="Report Received", icon_url=ctx.author.avatar_url)
+            .set_author(name="Report Received", icon_url=ctx.author.display_avatar.url)
             .add_field(name="Server", value=ctx.guild.name)
             .add_field(name="Channel", value=ctx.channel.mention)
             .add_field(name="Timestamp", value=f"<t:{int(ctx.message.created_at.timestamp())}:F>")

--- a/timeout/timeout.py
+++ b/timeout/timeout.py
@@ -47,10 +47,10 @@ class Timeout(commands.Cog):
             inline=False
         )
 
-        if user.avatar_url:
+        if user.display_avatar:
             embed.set_author(
                 name=f"{user} {action_info['action']} timeout",
-                icon_url=user.avatar_url)
+                icon_url=user.display_avatar.url)
         else:
             embed.set_author(
                 name=f"{user} {action_info['action']} timeout"
@@ -236,7 +236,7 @@ class Timeout(commands.Cog):
         )
         embed.set_author(
             name="Timeout Cog Settings",
-            icon_url=ctx.guild.me.avatar_url
+            icon_url=ctx.guild.me.display_avatar.url
         )
         embed.add_field(
             name="Log Channel",

--- a/verify/verify.py
+++ b/verify/verify.py
@@ -419,7 +419,7 @@ class VerifyCog(commands.Cog):
         if log_id:
             log = guild.get_channel(log_id)
             data = discord.Embed(color=discord.Color.orange())
-            data.set_author(name=f"{message} - {user}", icon_url=user.avatar_url)
+            data.set_author(name=f"{message} - {user}", icon_url=user.display_avatar.url)
             data.add_field(name="User", value=user.mention)
             data.add_field(name="ID", value=user.id)
             if not failmessage:


### PR DESCRIPTION
# Initial Checklist
- [x] Has @tigattack / @issy been added as a reviewer?
- [ ] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**
Resolves #224

## Changes
### Features / Fixes
* Replaces `Member.avatar_url` ([removed in discord.py v2](https://discordpy.readthedocs.io/en/latest/migrating.html#asset-redesign-and-changes)) with `Member.display_avatar.url`.

### Breaking Changes
* Bloody well hope not.

## Additional

Thanks @portalBlock :heart:
