### PR TITLE
discordpy v2 migrations

### DIFF
--- a/enforcer/enforcer.py
+++ b/enforcer/enforcer.py
@@ -1,6 +1,5 @@
 """discord red-bot enforcer"""
 import asyncio
-from datetime import datetime
 from typing import Union
 
 import discord

--- a/enforcer/enforcer.py
+++ b/enforcer/enforcer.py
@@ -271,13 +271,13 @@ class EnforcerCog(commands.Cog):
             return False
 
         if KEY_MINDISCORDAGE in channel and author.created_at:
-            delta = datetime.utcnow() - author.created_at
+            delta = discord.utils.utcnow() - author.created_at
             if delta.total_seconds() < channel[KEY_MINDISCORDAGE]:
                 # They breached minimum discord age
                 return "User account not old enough"
 
         if KEY_MINGUILDAGE in channel and author.joined_at:
-            delta = datetime.utcnow() - author.joined_at
+            delta = discord.utils.utcnow() - author.joined_at
             if delta.total_seconds() < channel[KEY_MINGUILDAGE]:
                 # They breached minimum guild age
                 return "User not in server long enough"

--- a/verify/verify.py
+++ b/verify/verify.py
@@ -1,5 +1,5 @@
 """discord red-bot verify"""
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import discord
 import Levenshtein as lev

--- a/verify/verify.py
+++ b/verify/verify.py
@@ -59,7 +59,7 @@ class VerifyCog(commands.Cog):
             return
 
         mintime = await self.config.guild(guild).mintime()
-        minjoin = datetime.utcnow() - timedelta(seconds=mintime)
+        minjoin = discord.utils.utcnow() - timedelta(seconds=mintime)
         if author.joined_at > minjoin:
             # User tried to verify too fast
             tooquick = await self.config.guild(guild).tooquick()


### PR DESCRIPTION
# Initial Checklist
- [x] Has @tigattack / @issy been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**
Resolves #229

## Changes
### Features / Fixes
* replace `datetime.utcnow()` with `discord.utils.utcnow()`
    See [`datetime` Objects Are Now UTC-Aware](https://discordpy.readthedocs.io/en/latest/migrating.html#datetime-objects-are-now-utc-aware)

### Breaking Changes
* hope not !

## Additional

Hopefully this is the last of it.
