### PR TITLE
feat/feed: add context menu commands

### DIFF
--- a/feed/__init__.py
+++ b/feed/__init__.py
@@ -1,7 +1,16 @@
+from discord import AppCommandType
 from redbot.core.bot import Red
 
-from .feed import FeedCog
+from .feed import FeedCog, on_message, on_user
 
 
 async def setup(bot: Red):
     await bot.add_cog(FeedCog())
+    bot.tree.add_command(on_message)
+    bot.tree.add_command(on_user)
+
+
+async def teardown(bot: Red):
+    await bot.remove_cog(FeedCog())
+    bot.tree.remove_command("Feed", type=AppCommandType.message)
+    bot.tree.remove_command("Feed", type=AppCommandType.user)

--- a/feed/feed.py
+++ b/feed/feed.py
@@ -2,7 +2,7 @@
 import random
 
 import discord
-from redbot.core import commands, app_commands
+from redbot.core import app_commands, commands
 
 food = (
     "🍇",

--- a/feed/feed.py
+++ b/feed/feed.py
@@ -2,7 +2,7 @@
 import random
 
 import discord
-from redbot.core import commands
+from redbot.core import commands, app_commands
 
 food = (
     "🍇",
@@ -119,16 +119,30 @@ food = (
 )
 
 
+@app_commands.context_menu(name="Feed user")
+async def on_user(interaction: discord.Interaction, member: discord.User):
+    """Feed user from user context"""
+    await do_feed(interaction, member.mention)
+
+
+@app_commands.context_menu(name="Feed user")
+async def on_message(interaction: discord.Interaction, message: discord.Message):
+    """Feed user from message context"""
+    await do_feed(interaction, message.author.mention)
+
+
+async def do_feed(interaction: discord.Interaction, mention: str):
+    feed_text = f"Forces {random.choice(food)} down {mention}'s throat"
+    allowed_mentions = discord.AllowedMentions(everyone=False, users=True, roles=False)
+    await interaction.response.send_message(feed_text, allowed_mentions=allowed_mentions)
+
+
 class FeedCog(commands.Cog):
     """Feed Cog"""
 
     @commands.command(name="feed")
-    async def feed(self, ctx, member: discord.Member):
-        """Feed your friends
-
-        Example:
-        - `[p]feed <member>`
-        """
-        feed_text = f"Forces {random.choice(food)} down {member.display_name}'s throat"
-        allowed_mentions = discord.AllowedMentions(everyone=False, users=True, roles=False)
-        await ctx.send(feed_text, allowed_mentions=allowed_mentions)
+    async def feed(self, ctx):
+        """Feed your friends"""
+        await ctx.send(
+            "Feed can now be used from the context menu of any user or message.\nThis command is no longer functional."
+        )

--- a/feed/feed.py
+++ b/feed/feed.py
@@ -118,31 +118,32 @@ food = (
     "🧊",
 )
 
+allowed_mentions = discord.AllowedMentions(everyone=False, users=True, roles=False)
+
+
+def get_fed(mention: str) -> str:
+    return f"Forces {random.choice(food)} down {mention}'s throat"
+
 
 @app_commands.context_menu(name="Feed user")
 async def on_user(interaction: discord.Interaction, member: discord.User):
     """Feed user from user context"""
-    await do_feed(interaction, member.mention)
+    await interaction.response.send_message(get_fed(member.mention), allowed_mentions=allowed_mentions)
 
 
 @app_commands.context_menu(name="Feed user")
 async def on_message(interaction: discord.Interaction, message: discord.Message):
     """Feed user from message context"""
-    await do_feed(interaction, message.author.mention)
-
-
-async def do_feed(interaction: discord.Interaction, mention: str):
-    feed_text = f"Forces {random.choice(food)} down {mention}'s throat"
-    allowed_mentions = discord.AllowedMentions(everyone=False, users=True, roles=False)
-    await interaction.response.send_message(feed_text, allowed_mentions=allowed_mentions)
+    await interaction.response.send_message(get_fed(message.author.mention), allowed_mentions=allowed_mentions)
 
 
 class FeedCog(commands.Cog):
     """Feed Cog"""
 
     @commands.command(name="feed")
-    async def feed(self, ctx):
-        """Feed your friends"""
-        await ctx.send(
-            "Feed can now be used from the context menu of any user or message.\nThis command is no longer functional."
-        )
+    async def feed(self, ctx, member: discord.Member):
+        """Feed your friends
+        Example:
+        - `[p]feed <member>`
+        """
+        await ctx.send(get_fed(member.mention), allowed_mentions=allowed_mentions)


### PR DESCRIPTION
# Initial Checklist
- [x] Has @tigattack / @issy been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [x] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**
nah

## Changes
### Features / Fixes
* Feed will now be available from the user and message context menus and will mention the user being fed.

### Breaking Changes
hope not

## Additional

![image](https://github.com/rHomelab/LabBot-Cogs/assets/10629864/a243fff8-aa21-4c52-bb42-44c59a0f9f38)

![image](https://github.com/rHomelab/LabBot-Cogs/assets/10629864/f95aea89-361b-49f5-9c4f-74ef50f55115)
