### PR TITLE
chore: remove deprecated VSCode setting

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+      "ms-python.black-formatter",
+      "ms-python.isort",
+      "ms-python.pylint",
+      "ms-python.python",
+      "ms-python.vscode-pylance",
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.linting.pylintEnabled": true
-}


### PR DESCRIPTION
# Initial Checklist
- [x] Has @tigattack / @issy been added as a reviewer?
- [ ] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**
No

## Changes
### Features / Fixes
* Removes deprecated VSCode setting

### Breaking Changes
N/A

## Additional

All settings starting with "python.linting." are deprecated and can be removed from settings. https://code.visualstudio.com/docs/python/linting
https://code.visualstudio.com/docs/python/linting
