### PR TITLE
bancount: remove limitation on number of bans retrieved and catch missing permissions

### DIFF
--- a/bancount/bancount.py
+++ b/bancount/bancount.py
@@ -1,5 +1,6 @@
 import random
 
+import discord.errors
 from redbot.core import Config, checks, commands
 from redbot.core.bot import Red
 
@@ -31,7 +32,12 @@ class BanCountCog(commands.Cog):
                 await ctx.send("Error: guild has no configured messages. Use `[p]bancount add <message>`.")
                 return
             message = random.choice(messages)
-            message = message.replace(self.REPLACER, str(len([entry async for entry in ctx.guild.bans()])))
+            try:
+                async with ctx.channel.typing():
+                    message = message.replace(self.REPLACER, str(len([entry async for entry in ctx.guild.bans()])))
+            except discord.errors.Forbidden:
+                await ctx.send("I don't have permission to retrieve banned users.")
+                return
             await ctx.send(message)
 
     @checks.mod()

--- a/bancount/bancount.py
+++ b/bancount/bancount.py
@@ -34,7 +34,7 @@ class BanCountCog(commands.Cog):
             message = random.choice(messages)
             try:
                 async with ctx.channel.typing():
-                    message = message.replace(self.REPLACER, str(len([entry async for entry in ctx.guild.bans()])))
+                    message = message.replace(self.REPLACER, str(len([entry async for entry in ctx.guild.bans(limit=None)])))
             except discord.errors.Forbidden:
                 await ctx.send("I don't have permission to retrieve banned users.")
                 return


### PR DESCRIPTION
# Initial Checklist
- [ ] Has @tigattack / @issy been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**
N/A.

## Changes
### Features / Fixes
* Removes the default limit of 1000 on `Guild.bans`
* Catches missing permissions when attempting to retrieve bans
* Uses `typing()` to send a typing indicator while ban list is being retrieved.

### Breaking Changes
N/A.

## Additional
N/A.
