### PR TITLE
feat(custom_msg): return link to sent message

### DIFF
--- a/custom_msg/custom_msg.py
+++ b/custom_msg/custom_msg.py
@@ -29,7 +29,7 @@ class CustomMsgCog(commands.Cog):
         message = await channel.send(**payload)
         await ctx.send("Message sent. " +
                        "For future reference, the message is here: " +
-                       f"https://discord.com/channels/184315303323238400/{message.channel.id}/{message.id} (ID: {message.id})")
+                       f"https://discord.com/channels/{ctx.guild.id}/{message.channel.id}/{message.id} (ID: {message.id})")
 
     @msg_cmd.command(name="edit")
     async def msg_edit(self, ctx: commands.Context, message: discord.Message):

--- a/custom_msg/custom_msg.py
+++ b/custom_msg/custom_msg.py
@@ -27,7 +27,9 @@ class CustomMsgCog(commands.Cog):
             return await ctx.send("Exiting...")
 
         message = await channel.send(**payload)
-        await ctx.send(f"Message sent.\nFor future reference, the message ID is {message.channel.id}-{message.id}")
+        await ctx.send("Message sent. " +
+                       "For future reference, the message is here: " +
+                       f"https://discord.com/channels/184315303323238400/{message.channel.id}/{message.id} (ID: {message.id})")
 
     @msg_cmd.command(name="edit")
     async def msg_edit(self, ctx: commands.Context, message: discord.Message):
@@ -45,13 +47,15 @@ class CustomMsgCog(commands.Cog):
 
         if not payload.get("content") and message.content:
             if not await InteractiveSession(ctx).get_boolean_answer(
-                "The original message has message content, but you have not specified any. Would you like to keep the original content?"
+                "The original message has message content, but you have not specified any. " +
+                "Would you like to keep the original content?"
             ):
                 payload.update({"content": ""})
 
         if not payload.get("embed") and message.embeds:
             if not await InteractiveSession(ctx).get_boolean_answer(
-                "The original message has an embed, but you have not specified one. Would you like to keep the original embed?"
+                "The original message has an embed, but you have not specified one. " +
+                "Would you like to keep the original embed?"
             ):
                 payload.update({"embed": None})
 


### PR DESCRIPTION
# Initial Checklist
- [x] Has @tigattack / @issy been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [x] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**
No

## Changes
### Features / Fixes
* Makes the custom_msg cog return a clickable message link instead of `<channel_id>-<msg_id>`.

### Breaking Changes
N/A

## Additional
N/A
