### PR TITLE
fix prometheus_exporter logging, isort, activity metrics addition

### DIFF
--- a/prometheus_exporter/main.py
+++ b/prometheus_exporter/main.py
@@ -8,7 +8,6 @@ from .prom_server import PrometheusMetricsServer, promServer
 from .stats import Poller, statApi
 
 logger = logging.getLogger("red.rhomelab.prom")
-logger.setLevel(logging.DEBUG)
 
 
 class PromExporter(commands.Cog):

--- a/prometheus_exporter/prom_server.py
+++ b/prometheus_exporter/prom_server.py
@@ -7,7 +7,6 @@ from wsgiref.simple_server import WSGIRequestHandler, make_server
 
 from prometheus_client import CollectorRegistry, make_wsgi_app
 
-
 logger = logging.getLogger("red.rhomelab.prom.server")
 
 

--- a/prometheus_exporter/stats.py
+++ b/prometheus_exporter/stats.py
@@ -121,6 +121,7 @@ class Poller(statApi):
 
         for member in guild.members:
             if member.activity is not None and "unknown" not in member.activity.type.name:
+                data_types[member.activity.type.name] += 1
                 logger.debug("post user activity stats collection")
 
 

--- a/prometheus_exporter/stats.py
+++ b/prometheus_exporter/stats.py
@@ -120,7 +120,7 @@ class Poller(statApi):
         data_types = {value.name: 0 for value in discord.ActivityType if  "unknown" not in value.name }
 
         for member in guild.members:
-            if member.activity is not None and "unknown" not in member.activity.type.name:
+            if member.activity is not None and member.activity.type.name in data_types:
                 data_types[member.activity.type.name] += 1
                 logger.debug("post user activity stats collection")
 

--- a/prometheus_exporter/stats.py
+++ b/prometheus_exporter/stats.py
@@ -120,8 +120,6 @@ class Poller(statApi):
         data_types = {value.name: 0 for value in discord.ActivityType if  "unknown" not in value.name }
 
         for member in guild.members:
-            logger.debug(member)
-
             if member.activity is not None and "unknown" not in member.activity.type.name:
                 logger.debug("post user activity stats collection")
 

--- a/prometheus_exporter/stats.py
+++ b/prometheus_exporter/stats.py
@@ -6,8 +6,8 @@ from typing import Optional, Protocol
 import discord
 from prometheus_client import Gauge
 from redbot.core.bot import Red
-from .utils import timeout
 
+from .utils import timeout
 
 logger = logging.getLogger("red.rhomelab.prom.stats")
 

--- a/prometheus_exporter/utils.py
+++ b/prometheus_exporter/utils.py
@@ -1,7 +1,7 @@
-from functools import wraps
-from typing import Awaitable, TYPE_CHECKING, Self
 import asyncio
 import logging
+from functools import wraps
+from typing import TYPE_CHECKING, Awaitable, Self
 
 if TYPE_CHECKING:
     from stats import Poller


### PR DESCRIPTION
# Initial Checklist
- [x] Has @tigattack / @issy been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**
Not logged in issues but yes - @rippleFCL's decision to log every single member and force the log level to debug resulted in never-ending log spam.

## Changes
### Features / Fixes
* Fixes enforced `DEBUG` log level.
* Fixes the existence of an unnecessary log statement.
* Re-adds the activity metrics addition statement, erroneously removed in d28819d.
