### PR TITLE
fix(report): reimplement strtobool to eliminate distutils dependency

### DIFF
--- a/report/report.py
+++ b/report/report.py
@@ -1,5 +1,4 @@
 """discord red-bot report cog"""
-from distutils.util import strtobool
 
 import discord
 from redbot.core import Config, checks, commands
@@ -195,3 +194,10 @@ class ReportCog(commands.Cog):
             .add_field(name="Channel", value=ctx.channel.mention)
             .add_field(name="Timestamp", value=f"<t:{int(ctx.message.created_at.timestamp())}:F>")
         )
+
+
+def strtobool(value: str) -> bool:
+    value = value.lower()
+    if value in ("y", "yes", "on", "1", "true", "t"):
+        return True
+    return False


### PR DESCRIPTION
# Initial Checklist
- [x] Has @tigattack / @issy been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**
Resolves #272 

## Changes
### Features / Fixes
* Removes dependency on the deprecated `distutils` package.
  See PEP 632 for context.
  I feel there may be a better/more recommended way to handle the way this function is used in the cog, but this is a quick and simple fix.


### Breaking Changes

## Additional
