### PR TITLE
fix(xkcd): invert boolean logic for alt text presence

### DIFF
--- a/xkcd/xkcd.py
+++ b/xkcd/xkcd.py
@@ -49,7 +49,7 @@ class Xkcd(commands.Cog):
         xkcd_embed.add_field(name="Comic Title", value=data["safe_title"])
         xkcd_embed.add_field(name="Publish Date", value=f"{data['year']}-{data['month']}-{data['day']}")
         # If there is alt text add it to the embed, otherwise don't
-        if not data["alt"]:
+        if data["alt"]:
             xkcd_embed.add_field(name="Comic Alt Text", value=data["alt"])
         else:
             pass


### PR DESCRIPTION
# Initial Checklist
- [x] Has @tigattack / @issy been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**
Resolves #274

## Changes
### Features / Fixes
* Fixes missing alt text even when present for requested comic.

### Breaking Changes

## Additional

