### PR TITLE
fix: hotfix for bad `GuildChannel` type reference

### DIFF
--- a/enforcer/enforcer.py
+++ b/enforcer/enforcer.py
@@ -49,7 +49,7 @@ class EnforcerCog(commands.Cog):
 
         self.config.register_guild(**default_guild_settings, force_registration=True)
 
-    def _is_valid_channel(self, channel: discord.guild.GuildChannel | None):
+    def _is_valid_channel(self, channel: discord.abc.GuildChannel | None):
         if channel is not None and not isinstance(channel, (discord.ForumChannel, discord.CategoryChannel)):
             return channel
         return False

--- a/markov/markov.py
+++ b/markov/markov.py
@@ -408,7 +408,7 @@ class Markov(commands.Cog):
         # Return true (i.e. should process message) if all checks passed
         return True
 
-    async def get_enabled_channels(self, guild: discord.Guild) -> list[discord.guild.GuildChannel]:
+    async def get_enabled_channels(self, guild: discord.Guild) -> list[discord.abc.GuildChannel]:
         """Retrieve a list of enabled channels in a given guild"""
         # Retrieve and iterate over enabled channels in specified guild,
         # appending each channel to the list of enabled channels.

--- a/quotes/quotes.py
+++ b/quotes/quotes.py
@@ -187,7 +187,7 @@ class QuotesCog(commands.Cog):
         error_embed = discord.Embed(title="Error", description=error_msg, colour=await ctx.embed_colour())
         await ctx.send(embed=error_embed)
 
-    def _is_valid_channel(self, channel: discord.guild.GuildChannel | discord.abc.MessageableChannel | None):
+    def _is_valid_channel(self, channel: discord.abc.GuildChannel | discord.abc.MessageableChannel | None):
         if channel is not None and not isinstance(
             channel,
             (

--- a/reactrole/reactrole.py
+++ b/reactrole/reactrole.py
@@ -27,7 +27,7 @@ class ReactRoleCog(commands.Cog):
 
         self.config.register_guild(**default_guild_settings)
 
-    def _is_valid_channel(self, channel: discord.guild.GuildChannel | None):
+    def _is_valid_channel(self, channel: discord.abc.GuildChannel | None):
         if channel is not None and not isinstance(channel, (discord.ForumChannel, discord.CategoryChannel)):
             return channel
         return False

--- a/report/report.py
+++ b/report/report.py
@@ -29,7 +29,7 @@ class ReportCog(commands.Cog):
 
         self.config.register_guild(**default_guild_settings)
 
-    def _is_valid_channel(self, channel: discord.guild.GuildChannel | None):
+    def _is_valid_channel(self, channel: discord.abc.GuildChannel | None):
         if channel is not None and not isinstance(channel, (discord.ForumChannel, discord.CategoryChannel)):
             return channel
         return False

--- a/timeout/timeout.py
+++ b/timeout/timeout.py
@@ -22,7 +22,7 @@ class Timeout(commands.Cog):
 
     # Helper functions
 
-    def _is_valid_channel(self, channel: discord.guild.GuildChannel | None):
+    def _is_valid_channel(self, channel: discord.abc.GuildChannel | None):
         if channel is not None and not isinstance(channel, (discord.ForumChannel, discord.CategoryChannel)):
             return channel
         return False

--- a/verify/verify.py
+++ b/verify/verify.py
@@ -419,7 +419,7 @@ class VerifyCog(commands.Cog):
 
     # Helper functions
 
-    def _is_valid_channel(self, channel: discord.guild.GuildChannel | None):
+    def _is_valid_channel(self, channel: discord.abc.GuildChannel | None):
         if channel is not None and not isinstance(channel, (discord.ForumChannel, discord.CategoryChannel)):
             return channel
         return False


### PR DESCRIPTION
# Initial Checklist
- [ ] Has @tigattack been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details

Hotfix for `AttributeError` exception in several cogs due to bad type reference introduced in #264:

```
    def _is_valid_channel(self, channel: discord.guild.GuildChannel | None):
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'discord.guild' has no attribute 'GuildChannel'
```

This re-introduces some type errors, but is required to fix cog failures for the time being.