### PR TITLE
fix: hotfix for bad `MessageableChannel` type reference

### DIFF
--- a/quotes/quotes.py
+++ b/quotes/quotes.py
@@ -187,7 +187,7 @@ class QuotesCog(commands.Cog):
         error_embed = discord.Embed(title="Error", description=error_msg, colour=await ctx.embed_colour())
         await ctx.send(embed=error_embed)
 
-    def _is_valid_channel(self, channel: discord.abc.GuildChannel | discord.abc.MessageableChannel | None):
+    def _is_valid_channel(self, channel: discord.abc.GuildChannel | discord.abc.Messageable | None):
         if channel is not None and not isinstance(
             channel,
             (

--- a/topic/topic.py
+++ b/topic/topic.py
@@ -8,7 +8,7 @@ class Topic(commands.Cog):
     def __init__(self):
         pass
 
-    def _is_valid_channel(self, channel: discord.abc.MessageableChannel | discord.interactions.InteractionChannel | None):
+    def _is_valid_channel(self, channel: discord.abc.Messageable | discord.interactions.InteractionChannel | None):
         if channel is not None and not isinstance(
             channel,
             (


### PR DESCRIPTION
# Initial Checklist
- [ ] Has @tigattack been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details

Hotfix for `AttributeError` exception in several cogs due to bad type reference introduced in #264:

```
    def _is_valid_channel(self, channel: discord.abc.MessageableChannel | discord.interactions.InteractionChannel | None):
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'discord.abc' has no attribute 'MessageableChannel'
```

This re-introduces some type errors, but is required to fix cog failures for the time being.