### PR TITLE
fix(topic): quote type reference that doesn't exist at runtime

### DIFF
--- a/topic/topic.py
+++ b/topic/topic.py
@@ -8,7 +8,7 @@ class Topic(commands.Cog):
     def __init__(self):
         pass
 
-    def _is_valid_channel(self, channel: discord.abc.Messageable | discord.interactions.InteractionChannel | None):
+    def _is_valid_channel(self, channel: "discord.interactions.InteractionChannel | None"):
         if channel is not None and not isinstance(
             channel,
             (


### PR DESCRIPTION
shame on ripple

# Initial Checklist
- [x] Has @tigattack been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**
Resolves #304 

## Changes
### Features / Fixes
* quote type as it doesn't exist in scope

