### PR TITLE
fix: restore types and quote them instead

### DIFF
--- a/enforcer/enforcer.py
+++ b/enforcer/enforcer.py
@@ -49,7 +49,7 @@ class EnforcerCog(commands.Cog):
 
         self.config.register_guild(**default_guild_settings, force_registration=True)
 
-    def _is_valid_channel(self, channel: discord.abc.GuildChannel | None):
+    def _is_valid_channel(self, channel: "discord.guild.GuildChannel | None"):
         if channel is not None and not isinstance(channel, (discord.ForumChannel, discord.CategoryChannel)):
             return channel
         return False

--- a/markov/markov.py
+++ b/markov/markov.py
@@ -408,7 +408,7 @@ class Markov(commands.Cog):
         # Return true (i.e. should process message) if all checks passed
         return True
 
-    async def get_enabled_channels(self, guild: discord.Guild) -> list[discord.abc.GuildChannel]:
+    async def get_enabled_channels(self, guild: discord.Guild) -> "list[discord.guild.GuildChannel]":
         """Retrieve a list of enabled channels in a given guild"""
         # Retrieve and iterate over enabled channels in specified guild,
         # appending each channel to the list of enabled channels.

--- a/quotes/quotes.py
+++ b/quotes/quotes.py
@@ -187,7 +187,7 @@ class QuotesCog(commands.Cog):
         error_embed = discord.Embed(title="Error", description=error_msg, colour=await ctx.embed_colour())
         await ctx.send(embed=error_embed)
 
-    def _is_valid_channel(self, channel: discord.abc.GuildChannel | discord.abc.Messageable | None):
+    def _is_valid_channel(self, channel: "discord.guild.GuildChannel | discord.abc.MessageableChannel | None"):
         if channel is not None and not isinstance(
             channel,
             (

--- a/reactrole/reactrole.py
+++ b/reactrole/reactrole.py
@@ -27,7 +27,7 @@ class ReactRoleCog(commands.Cog):
 
         self.config.register_guild(**default_guild_settings)
 
-    def _is_valid_channel(self, channel: discord.abc.GuildChannel | None):
+    def _is_valid_channel(self, channel: "discord.guild.GuildChannel | None"):
         if channel is not None and not isinstance(channel, (discord.ForumChannel, discord.CategoryChannel)):
             return channel
         return False

--- a/report/report.py
+++ b/report/report.py
@@ -29,7 +29,7 @@ class ReportCog(commands.Cog):
 
         self.config.register_guild(**default_guild_settings)
 
-    def _is_valid_channel(self, channel: discord.abc.GuildChannel | None):
+    def _is_valid_channel(self, channel: "discord.guild.GuildChannel | None"):
         if channel is not None and not isinstance(channel, (discord.ForumChannel, discord.CategoryChannel)):
             return channel
         return False

--- a/timeout/timeout.py
+++ b/timeout/timeout.py
@@ -22,7 +22,7 @@ class Timeout(commands.Cog):
 
     # Helper functions
 
-    def _is_valid_channel(self, channel: discord.abc.GuildChannel | None):
+    def _is_valid_channel(self, channel: "discord.guild.GuildChannel | None"):
         if channel is not None and not isinstance(channel, (discord.ForumChannel, discord.CategoryChannel)):
             return channel
         return False

--- a/topic/topic.py
+++ b/topic/topic.py
@@ -8,7 +8,7 @@ class Topic(commands.Cog):
     def __init__(self):
         pass
 
-    def _is_valid_channel(self, channel: discord.abc.Messageable | discord.interactions.InteractionChannel | None):
+    def _is_valid_channel(self, channel: "discord.abc.MessageableChannel | discord.interactions.InteractionChannel | None"):
         if channel is not None and not isinstance(
             channel,
             (

--- a/verify/verify.py
+++ b/verify/verify.py
@@ -419,7 +419,7 @@ class VerifyCog(commands.Cog):
 
     # Helper functions
 
-    def _is_valid_channel(self, channel: discord.abc.GuildChannel | None):
+    def _is_valid_channel(self, channel: "discord.guild.GuildChannel | None"):
         if channel is not None and not isinstance(channel, (discord.ForumChannel, discord.CategoryChannel)):
             return channel
         return False


### PR DESCRIPTION
# Initial Checklist
- [x] Has @tigattack been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**
Resolves #304 

## Additional
#302 and #303 switched to runtime available types for a hotfix. These are incorrect.

This change switches back to the original correct types but quotes them so it doesn't cause runtime issues.