### PR TITLE
fix(notes): escape markdown in usernames

### DIFF
--- a/notes/notes.py
+++ b/notes/notes.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import discord
 from redbot.core import checks, commands
-from redbot.core.utils.chat_formatting import pagify
+from redbot.core.utils.chat_formatting import escape, pagify
 from redbot.core.utils.menus import close_menu, menu, next_page, prev_page
 
 from .utils import MAYBE_MEMBER, ConfigHelper, NoteException
@@ -123,7 +123,9 @@ class NotesCog(commands.Cog):
         pages = list(pagify("\n\n".join(str(n) for n in notes)))
 
         # Create embeds from pagified data
-        notes_target: Optional[str] = getattr(user, "display_name", str(user.id)) if user is not None else None
+        notes_target: Optional[str] = (
+            escape(getattr(user, "display_name", str(user.id)), formatting=True) if user is not None else None
+        )
         base_embed_options = {
             "title": (
                 (f"Notes for {notes_target}" if notes_target else "All notes")

--- a/notes/utils.py
+++ b/notes/utils.py
@@ -3,6 +3,7 @@ from typing import Callable, Iterable, List, Union
 
 import discord
 from redbot.core import Config, commands
+from redbot.core.utils.chat_formatting import escape
 
 from .abstracts import ConfigHelperABC, NoteABC
 
@@ -44,7 +45,7 @@ class Note(NoteABC):
 
     def __str__(self) -> str:
         icon = "\N{WARNING SIGN}" if self.is_warning else "\N{MEMO}"
-        member_name = self._guild.get_member(self.member_id) or self.member_id
+        member_name = escape(str(self._guild.get_member(self.member_id) or self.member_id), formatting=True)
         reporter_name = self._guild.get_member(self.reporter_id) or self.reporter_name
         return (
             f"{icon} #{self.note_id} **{member_name} - Added by {reporter_name}** "


### PR DESCRIPTION
# Initial Checklist
- [ ] Has @tigattack been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**
Resolves issue where markdown control characters were not escaped in output of `[p]notes list`.

## Changes
### Features / Fixes
* Escapes markdown formatting in output of `[p]notes list`.
