### PR TITLE
fix(custom_msg): catch messages >2000 characters

### DIFF
--- a/custom_msg/interactive_session.py
+++ b/custom_msg/interactive_session.py
@@ -61,7 +61,15 @@ class InteractiveSession:
 
 class MessageBuilder(InteractiveSession):
     async def run(self) -> Payload:
-        content = await self.get_response("Please enter the message you want to send.")
+        max_length = 2000
+        while True:
+            content = await self.get_response("Please enter the message you want to send.")
+            content_length = len(content)
+            if content_length > max_length:
+                await self.ctx.send(f"Message must be {max_length} characters or less. Please try again.")
+                continue
+            break
+
         self.payload.update({"content": content})
         if await self.confirm_sample():
             return self.payload


### PR DESCRIPTION
# Initial Checklist
- [ ] Has @tigattack been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**
Resolves issue where messages longer than 2000 characters result in an uncaught exception.

## Changes
### Features / Fixes
* `custom_msg` catches messages >2000 characters and asks the user to retry.
