### PR TITLE
guild_profiles: reduce min perms, show 'typing..' during long ops

### DIFF
--- a/guild_profiles/guild_profiles.py
+++ b/guild_profiles/guild_profiles.py
@@ -191,7 +191,7 @@ class GuildProfilesCog(commands.Cog):
 
     @commands.group(name="guildprofile")  # type: ignore
     @commands.guild_only()
-    @checks.admin_or_permissions(manage_guild=True)
+    @checks.mod_or_permissions(manage_guild=True)
     async def guildprofile_cmd(self, ctx: commands.GuildContext):
         """Manage guild profiles and assets."""
         pass

--- a/guild_profiles/guild_profiles.py
+++ b/guild_profiles/guild_profiles.py
@@ -306,6 +306,9 @@ class GuildProfilesCog(commands.Cog):
             )
             return await ctx.send(f"No profile named '{name}' exists.")
 
+        # Show typing indicator while processing
+        await ctx.typing()
+
         profile = profiles[name]
         creator = ctx.guild.get_member(profile["creator"])
         creator_name = creator.mention if creator else "Unknown User"
@@ -436,6 +439,9 @@ class GuildProfilesCog(commands.Cog):
                 + f"attempted to apply a non-existent profile: {name}"
             )
             return await ctx.send(f"No profile named '{name}' exists.")
+
+        # Show typing indicator while processing
+        await ctx.typing()
 
         profile = profiles[name]
 
@@ -593,6 +599,9 @@ class GuildProfilesCog(commands.Cog):
             asset = await self._get_asset(ctx.guild, id)
         except (ValueError, FileNotFoundError) as e:
             return await ctx.send(f"Failed to retrieve asset: {e!s}")
+
+        # Show typing indicator while processing
+        await ctx.typing()
 
         creator = ctx.guild.get_member(asset.creator)
         creator_name = creator.mention if creator else "Unknown User"


### PR DESCRIPTION
# Initial Checklist
- [ ] Has @tigattack been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**

No issue logged, but mods were unable to use the command due to restrictive minimum permissions.

## Changes
### Features / Fixes
* Bot now shows typing indicator during long-running operations (asset uploads)
* Minimum permissions reduced from admins or those with `manage_guild` to mods or those with `manage_guild`.

### Breaking Changes
N/A.

## Additional
N/A.
