### PR TITLE
fix(onboarding_role): ensure bot is ready before checking roles in guilds

### DIFF
--- a/onboarding_role/onboarding_role.py
+++ b/onboarding_role/onboarding_role.py
@@ -59,8 +59,15 @@ class OnboardingRole(commands.Cog):
         - Has completed onboarding.
         - Does not have the onboarded role.
         """
+        # Wait until Red is fully ready and cache is populated
+        await self.bot.wait_until_red_ready()
+
         for guild in self.bot.guilds:
             onboarded_role_id = await self.config.guild(guild).role()
+            if not onboarded_role_id:
+                # No role configured for this guild
+                continue
+
             onboarded_role = guild.get_role(onboarded_role_id)
             if not onboarded_role:
                 # Role not found


### PR DESCRIPTION
# Initial Checklist
- [ ] Has @tigattack been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**
Not logged.

## Changes
### Features / Fixes
* Fixes issue where cog attempts to check for the configured role too early and consequently skips the on-start onboarding.
* Fixes issue where a false-positive warning will fire if no role is configured.