### PR TITLE
Fix emergency reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ When a user triggers the emergency command, all online/idle users in the log cha
 
 #### Configuration Commands
 
-- `[p]reports confirmation <true|false>` - Sets whether the bot will send users a confirmation/copy of their report.
+- `[p]reports confirmation <true|false>` - Sets whether the bot will DM users a confirmation/copy of their report. Confirmations are always provided when the slash command is used.
 - `[p]reports logchannel #admin-log` - Set the channel to which reports will be sent. ⚠️ The cog will not function without this.
 - `[p]reports maxmentions <number>` - Set the maximum number of users to mention in emergency reports (1-100, default: 20).
 - `[p]reports status` - Output the cog's configuration status.

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ The `report` and `emergency` commands have cooldowns defined; if a user attempts
 
 #### Emergency Reports
 
-When a user triggers the emergency command, all online/idle users in the log channel, with the following conditions:
+When a user triggers the emergency command, the bot will mention all online/idle users in the log channel with the user's report. The following conditions apply:
 
 * If no users in the log channel are online/idle, the cog will fall back to mentioning all non-bot users.
 * No number of users greather than the value of the `maxmentions` setting will be mentioned. The order of mentions is not guaranteed, so who is/isn't mentioned under this condition may be unpredictable.

--- a/README.md
+++ b/README.md
@@ -376,11 +376,24 @@ This cog will allow members to send a report into a channel where it can be revi
 
 The `report` and `emergency` commands have cooldowns defined; if a user attempts to use one of these commands more than once within a 30 second period, they will be rate limited and receive a message informing them of this.
 
+#### Emergency Reports
+
+When a user triggers the emergency command, all online/idle users in the log channel, with the following conditions:
+
+* If no users in the log channel are online/idle, the cog will fall back to mentioning all non-bot users.
+* No number of users greather than the value of the `maxmentions` setting will be mentioned. The order of mentions is not guaranteed, so who is/isn't mentioned under this condition may be unpredictable.
+
+#### Configuration Commands
+
 - `[p]reports confirmation <true|false>` - Sets whether the bot will send users a confirmation/copy of their report.
 - `[p]reports logchannel #admin-log` - Set the channel to which reports will be sent. ⚠️ The cog will not function without this.
+- `[p]reports maxmentions <number>` - Set the maximum number of users to mention in emergency reports (1-100, default: 20).
 - `[p]reports status` - Output the cog's configuration status.
+
+#### User Commands
+
 - `[p]report <message>` - Sends a report with the given message.
-- `[p]emergency <message>` - Sends a report with the given message, mentioning (@'ing) all users in the configured `logchannel` who are in either an online or idle state.
+- `[p]emergency <message>` - Sends a high-priority report with the given message, mentioning (@'ing) users in the configured `logchannel` who are in either an online or idle state.
 
 > [!TIP]
 > The `report` and `emergency` commands are also implemented as slash commands.

--- a/report/report.py
+++ b/report/report.py
@@ -179,11 +179,12 @@ class ReportCog(commands.Cog):
 
         embed = await self.make_report_embed(channel, message, report_body, emergency)
         msg_body = None
-        if isinstance(channel, TextLikeChannel):
+        if isinstance(log_channel, TextLikeChannel):
             # Ping online and idle mods or all mods if none with such a status are found.
             if emergency:
                 channel_members = [
-                    channel.guild.get_member(i.id) if isinstance(i, discord.ThreadMember) else i for i in channel.members
+                    log_channel.guild.get_member(i.id) if isinstance(i, discord.ThreadMember) else i
+                    for i in log_channel.members
                 ]
                 msg_body = " ".join(
                     [

--- a/report/report.py
+++ b/report/report.py
@@ -10,7 +10,7 @@ from redbot.core.utils.chat_formatting import escape
 
 logger = logging.getLogger("red.rhomelab.report")
 
-TextLikeChannnel: TypeAlias = discord.VoiceChannel | discord.StageChannel | discord.TextChannel | discord.Thread
+TextLikeChannel: TypeAlias = discord.VoiceChannel | discord.StageChannel | discord.TextChannel | discord.Thread
 GuildChannelOrThread: TypeAlias = "discord.guild.GuildChannel | discord.Thread"
 
 
@@ -31,7 +31,7 @@ class ReportCog(commands.Cog):
 
         self.config.register_guild(**default_guild_settings)
 
-    def _is_valid_channel(self, channel: "GuildChannelOrThread | None") -> TextLikeChannnel | Literal[False]:
+    def _is_valid_channel(self, channel: "GuildChannelOrThread | None") -> TextLikeChannel | Literal[False]:
         if channel is not None and not isinstance(channel, (discord.ForumChannel, discord.CategoryChannel)):
             return channel
         return False
@@ -133,7 +133,7 @@ class ReportCog(commands.Cog):
                 await ctx.message.delete()
                 await ctx.author.send(f"You are on cooldown. Try again in <t:{error.retry_after}:R>")
 
-    async def get_log_channel(self, guild: discord.Guild) -> TextLikeChannnel | None:
+    async def get_log_channel(self, guild: discord.Guild) -> TextLikeChannel | None:
         """Gets the log channel for the guild"""
         log_id = await self.config.guild(guild).logchannel()
         log = None
@@ -179,7 +179,7 @@ class ReportCog(commands.Cog):
 
         embed = await self.make_report_embed(channel, message, report_body, emergency)
         msg_body = None
-        if isinstance(channel, TextLikeChannnel):
+        if isinstance(channel, TextLikeChannel):
             # Ping online and idle mods or all mods if none with such a status are found.
             if emergency:
                 channel_members = [
@@ -220,7 +220,7 @@ class ReportCog(commands.Cog):
             .add_field(name="Timestamp", value=f"<t:{int(message.created_at.timestamp())}:F>")
         )
 
-        if isinstance(channel, TextLikeChannnel):
+        if isinstance(channel, TextLikeChannel):
             last_msg = [msg async for msg in channel.history(limit=1, before=message.created_at)][0]  # noqa: RUF015
             embed.add_field(name="Context Region", value=last_msg.jump_url if last_msg else "No messages found")
         else:

--- a/report/report.py
+++ b/report/report.py
@@ -10,9 +10,6 @@ from redbot.core.utils.chat_formatting import escape
 
 logger = logging.getLogger("red.rhomelab.report")
 
-# Discord's message content character limit is 4000, use a buffer for safety
-MAX_MESSAGE_LENGTH = 3900
-
 # Discord character limits
 EMBED_FIELD_VALUE_LIMIT = 1024
 MESSAGE_BODY_LIMIT = 2000
@@ -220,7 +217,7 @@ class ReportCog(commands.Cog):
 
         for mention in mentions_to_use:
             test_chunk = f"{current_chunk} {mention}".strip()
-            if len(test_chunk) > MAX_MESSAGE_LENGTH:
+            if len(test_chunk) > MESSAGE_BODY_LIMIT:
                 # Current chunk is full, start a new one
                 if current_chunk:
                     mention_chunks.append(current_chunk)


### PR DESCRIPTION
# Initial Checklist
- [ ] Has @tigattack been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**

Yes (not logged) 🥲 Commit 7ed73e09aa781a4fa6433a97ec5a360484f0946b was a big dumb on my part and has resulted in the emergency command being broken in almost all cases since then.

## Changes
### Features / Fixes
* Fixes broken emergency reports.
* Adds `maxmentions` setting to limit how many members of the log channel can be mentioned (default: 20).
* Adds character limit checks & handling.
	* Batch large numbers of user mentions across multiple messages
	* Truncate user reports, notifying them via interaction response or DM when this occurs.
* Improve logging and handling of other edge cases/potential errors.
* Always return report confirmations to interactions.
* Fixes some typos.

### Breaking Changes
Hopefully none :)
