### PR TITLE
refactor: datetime handling improvements

### DIFF
--- a/guild_profiles/guild_profiles.py
+++ b/guild_profiles/guild_profiles.py
@@ -1,7 +1,6 @@
 import logging
 import re
 from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Type
 
@@ -251,7 +250,7 @@ class GuildProfilesCog(commands.Cog):
             # Create the profile
             profiles[profile_name] = {
                 "creator": ctx.author.id,
-                "created": int(datetime.now(timezone.utc).timestamp()),
+                "created": int(discord.utils.utcnow().timestamp()),
                 "icon_id": icon_id,
                 "banner_id": banner_id,
             }
@@ -541,7 +540,7 @@ class GuildProfilesCog(commands.Cog):
         asset = GuildAsset(
             name=name.lower(),
             creator=ctx.author.id,
-            created=int(datetime.now(timezone.utc).timestamp()),
+            created=int(discord.utils.utcnow().timestamp()),
             path=file_path,
         )
 

--- a/jail/jail.py
+++ b/jail/jail.py
@@ -1,5 +1,4 @@
 import uuid
-from datetime import datetime
 from io import BytesIO
 from os import path
 from typing import Optional
@@ -28,7 +27,7 @@ class JailCog(commands.Cog):
     @commands.group("jail", pass_context=True, invoke_without_command=True)
     async def _jail(self, ctx: commands.Context, member: discord.Member):
         """Jails the specified user."""
-        jail = await self.config.create_jail(ctx, int(datetime.utcnow().timestamp()), member)
+        jail = await self.config.create_jail(ctx, int(discord.utils.utcnow().timestamp()), member)
         if jail is None:
             await ctx.send("Sorry, there was an error with jail category. Make sure things are setup correctly!")
             return

--- a/notes/utils.py
+++ b/notes/utils.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Callable, Iterable, List, Union
 
 import discord
@@ -23,7 +22,7 @@ class Note(NoteABC):
             message=message,
             reporter_id=ctx.author.id,
             reporter_name=ctx.author.name,
-            created_at=int(datetime.utcnow().timestamp()),
+            created_at=int(discord.utils.utcnow().timestamp()),
             deleted=False,
             is_warning=is_warning,
             _guild=ctx.guild,

--- a/purge/purge.py
+++ b/purge/purge.py
@@ -1,7 +1,7 @@
 """discord red-bot purge"""
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import discord
 from croniter import croniter
@@ -50,7 +50,7 @@ class PurgeCog(commands.Cog):
                     continue
 
                 # Is it time to run?
-                cur_epoch = datetime.utcnow()
+                cur_epoch = discord.utils.utcnow()
                 last_run = await self.config.guild(guild).lastrun()
                 last_run = last_run or 0
                 crontab = await self.config.guild(guild).schedule()
@@ -104,7 +104,7 @@ class PurgeCog(commands.Cog):
                 break
             users_kicked = new_list
 
-        data = discord.Embed(colour=discord.Colour.orange(), timestamp=datetime.utcnow())
+        data = discord.Embed(colour=discord.Colour.orange(), timestamp=discord.utils.utcnow())
         data.title = f"{title} Purge - Purged {len(users)}"
         data.description = users_kicked
 
@@ -141,7 +141,7 @@ class PurgeCog(commands.Cog):
 
             # If user is not older than the minimum age, they're safe
             timelimit = await self.config.guild(guild).minage()
-            cutoff_date = datetime.utcnow() - timedelta(days=timelimit)
+            cutoff_date = discord.utils.utcnow() - timedelta(days=timelimit)
             if member.joined_at > cutoff_date:
                 continue
 
@@ -339,12 +339,12 @@ class PurgeCog(commands.Cog):
 
         last_run_friendly = "Never"
         if purge_last_run is not None:
-            last_run = datetime.utcfromtimestamp(purge_last_run)
+            last_run = datetime.fromtimestamp(purge_last_run, tz=timezone.utc)
             last_run_friendly = last_run.strftime("%Y-%m-%d %H:%M:%SZ")
         data.add_field(name="Last Run", value=f"{last_run_friendly}")
 
         if (purge_last_run is not None or purge_enabled) and purge_schedule is not None:
-            next_date = croniter(purge_schedule, purge_last_run or datetime.utcnow()).get_next(datetime)
+            next_date = croniter(purge_schedule, purge_last_run or discord.utils.utcnow()).get_next(datetime)
             next_run_friendly = next_date.strftime("%Y-%m-%d %H:%M:%SZ")
 
             data.add_field(name="Next Run", value=f"{next_run_friendly}")

--- a/quotes/quotes.py
+++ b/quotes/quotes.py
@@ -158,7 +158,7 @@ class QuotesCog(commands.Cog):
             .add_field(name="Submitted by", value=ctx.author.mention)
             .add_field(name="Channels", value="\n".join(unique_channels))
             .add_field(name="Link", value=f"[Jump to quote]({messages[0].jump_url})")
-            .add_field(name="Timestamp", value=f"<t:{int(messages[0].created_at.timestamp())}:F>")
+            .add_field(name="Timestamp", value=discord.utils.format_dt(messages[0].created_at, "F"))
         )
 
     async def send_error(self, ctx, error_type: str = "", custom_msg: str = "") -> None:

--- a/report/report.py
+++ b/report/report.py
@@ -353,7 +353,7 @@ class ReportCog(commands.Cog):
             )
             .set_author(name="Report", icon_url=message.author.display_avatar.url)
             .add_field(name="Reporter", value=message.author.mention)
-            .add_field(name="Timestamp", value=f"<t:{int(message.created_at.timestamp())}:F>")
+            .add_field(name="Timestamp", value=discord.utils.format_dt(message.created_at, "F"))
         )
 
         if isinstance(channel, TextLikeChannel):

--- a/roleinfo/roleinfo.py
+++ b/roleinfo/roleinfo.py
@@ -42,5 +42,5 @@ class RoleInfoCog(commands.Cog):
             .add_field(name="Mentionable", value="Yes" if role.mentionable else "No")
             .add_field(name="Position", value=len(role.guild.roles) - role.position)
             .add_field(name="ID", value=role.id)
-            .add_field(name="Created at", value=f"<t:{int(role.created_at.timestamp())}:F>")
+            .add_field(name="Created at", value=discord.utils.format_dt(role.created_at, "F"))
         )

--- a/tags/tags.py
+++ b/tags/tags.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Optional
 
 import discord
@@ -54,7 +53,7 @@ class TagCog(commands.Cog):
         """Manage tags and aliases."""
         tag, alias = await self.config.get_tag_or_alias(ctx, trigger)
 
-        time = int(datetime.utcnow().timestamp())
+        time = int(discord.utils.utcnow().timestamp())
 
         if tag is None and alias is None:
             await ctx.send("That's not a valid tag or alias!")
@@ -162,7 +161,9 @@ class TagCog(commands.Cog):
                         f"wants to transfer it to you."
                     )
                 else:
-                    await self.config.transfer_tag(ctx, trigger, ctx.author.id, "Claim", int(datetime.utcnow().timestamp()))
+                    await self.config.transfer_tag(
+                        ctx, trigger, ctx.author.id, "Claim", int(discord.utils.utcnow().timestamp())
+                    )
                     await ctx.send("Tag successfully claimed!")
         else:
             await ctx.send("Sorry, that isn't a valid tag so you can't claim it. Good news! You can create it!")
@@ -182,7 +183,7 @@ class TagCog(commands.Cog):
                 reason = f"Mod-initiated by {ctx.author.mention}"
             if allowable:
                 await self.config.transfer_tag(
-                    ctx, trigger, member.id, f"Transfer: {reason}", int(datetime.utcnow().timestamp())
+                    ctx, trigger, member.id, f"Transfer: {reason}", int(discord.utils.utcnow().timestamp())
                 )
                 await ctx.send("Tag successfully transferred!")
             else:
@@ -253,7 +254,7 @@ class TagCog(commands.Cog):
             await ctx.send("You can't alias to another alias! That gets messy.")
             return
 
-        await self.config.create_alias(ctx, alias, tag, ctx.author.id, int(datetime.utcnow().timestamp()))
+        await self.config.create_alias(ctx, alias, tag, ctx.author.id, int(discord.utils.utcnow().timestamp()))
         await ctx.send("Alias created!")
 
     @_alias.command("delete")

--- a/tags/utils.py
+++ b/tags/utils.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import List, Optional
 
 import discord
@@ -93,7 +92,7 @@ class TagConfigHelper(TagConfigHelperABC):
         return self.config.guild(ctx.guild).log().uses.transfers(log)
 
     async def create_tag(self, ctx: commands.Context, trigger: str, content: str) -> Tag:
-        time = int(datetime.utcnow().timestamp())
+        time = int(discord.utils.utcnow().timestamp())
         tag = Tag.new(ctx, ctx.author.id, ctx.author.id, time, trigger, content)
         async with self.config.guild(ctx.guild).tags() as tags:
             tags[trigger] = tag.to_dict()

--- a/timeout/timeout.py
+++ b/timeout/timeout.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 from typing import Optional
 
@@ -36,7 +35,7 @@ class Timeout(commands.Cog):
 
         # Build embed
         embed = discord.Embed(
-            description=f"{user.mention} ({user.id})", color=(await ctx.embed_colour()), timestamp=datetime.datetime.utcnow()
+            description=f"{user.mention} ({user.id})", color=(await ctx.embed_colour()), timestamp=discord.utils.utcnow()
         )
         embed.add_field(name="Moderator", value=ctx.author.mention, inline=False)
         embed.add_field(name="Reason", value=action_info["reason"], inline=False)


### PR DESCRIPTION
# Initial Checklist
- [ ] Has @tigattack been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**
No

## Changes
### Features / Fixes
* Use timezone-aware datetime objects (mostly via substitution of `datetime.datetime.now()` with `discord.utils.utcnow()`)
* Use `discord.utils.format_dt()` to format datetimes for Discord instead of manually constructing strings.
