### PR TITLE
chore(renovate): add manager for cog deps

### DIFF
--- a/create_dev_bot.sh
+++ b/create_dev_bot.sh
@@ -30,7 +30,7 @@ python3 -m venv .venv
 source .venv/bin/activate
 
 echo "Installing dependencies..."
-pip install -r requirements.txt
+pip install -r requirements-dev.txt -r requirements.txt
 
 echo "Creating RedBot instance..."
 redbot-setup --instance-name "$INSTANCE_NAME" --no-prompt --data-path $DATA_PATH

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,32 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "jsonata",
+      "description": "Update cog requirements in info.json files",
+      "fileFormat": "json",
+      "managerFilePatterns": [
+        "/(^|/)info\\.json$/"
+      ],
+      "matchStrings": [
+        "$exists(requirements) and $count(requirements) > 0 ? $filter(requirements, function($v) { $match($v, /^([\\w.-]+)(>=|<=|==|!=|~=|>|<)(.+)$/) }).{ \"depName\": $match($, /^([\\w.-]+)(>=|<=|==|!=|~=|>|<)(.+)$/).groups[0], \"currentValue\": $match($, /^([\\w.-]+)(>=|<=|==|!=|~=|>|<)(.+)$/).groups[2] } : []"
+      ],
+      "datasourceTemplate": "pypi",
+      "versioningTemplate": "pep440"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchFileNames": ["requirements.txt"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["custom.jsonata"],
+      "rangeStrategy": "replace",
+      "commitMessageTopic": "cog requirement {{depName}}",
+      "commitMessageExtra": "to {{newValue}}"
+    }
   ]
 }


### PR DESCRIPTION
# Initial Checklist
- [ ] Has @tigattack been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**
No

## Changes
### Features / Fixes
* Adds Renovate custom manager and package rule to patch cog requirements.
* Adds Renovate package rule to ignore `requirements.txt` — This file is managed by a CI workflow which compiles all cog deps into one file.
* Fixes `create_dev_bot.sh` by installing dev requirements (`requirements-dev.txt`).
