### PR TITLE
ci(compile-requirements): prepend user ID to committer email

### DIFF
--- a/.github/workflows/compile-requirements.yml
+++ b/.github/workflows/compile-requirements.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.head_ref || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/compile-requirements.yml
+++ b/.github/workflows/compile-requirements.yml
@@ -43,7 +43,7 @@ jobs:
         if: steps.check_changes.outputs.changed == 'true'
         run: |
           git config --local user.name 'github-actions[bot]'
-          git config --local user.email 'github-actions[bot]@users.noreply.github.com'
+          git config --local user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add requirements.txt
           git commit -m "chore: update cog requirements.txt"
           git push


### PR DESCRIPTION
# Initial Checklist
- [ ] Has @tigattack been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**
Not logged

## Changes
### Features / Fixes
* Fixes pushing to PR source branches in `compile-requirements` workflow
* Corrects committer email in `compile-requirements` workflow by prepending user ID
