### PR TITLE
chore(renovate): don't ignore requirements.txt

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,10 +20,6 @@
   ],
   "packageRules": [
     {
-      "matchFileNames": ["requirements.txt"],
-      "enabled": false
-    },
-    {
       "matchManagers": ["custom.jsonata"],
       "rangeStrategy": "replace",
       "commitMessageTopic": "cog requirement {{depName}}",


### PR DESCRIPTION
# Initial Checklist
- [ ] Has @tigattack been added as a reviewer?
- [x] If applicable, have the relevant project(s), milestone(s), and label(s) been applied?
- [ ] If applicable, have you added details of the cog to the readme as per [README.md](https://github.com/rHomelab/LabBot-Cogs/blob/main/README.md#cog-summaries)?

<!-- FILL OUT THE BELOW SECTIONS AS APPROPRIATE -->

# Details
**Does this resolve an issue?**
Not logged

## Changes
### Features / Fixes
* Reverts part of #350 - This allows Renovate to patch both files at once (cog `info.json` & `requirements.txt`), which avoids the `compile-requirements` workflow modifying the PR and making Renovate unhappy.